### PR TITLE
Bug Fix: Allow Extra Environment Variables in Settings

### DIFF
--- a/src/celo_mcp/config/settings.py
+++ b/src/celo_mcp/config/settings.py
@@ -31,7 +31,7 @@ class Settings(BaseSettings):
 
         env_prefix = "CELO_MCP_"
         env_file = ".env"
-
+        extra = "ignore" 
 
 def get_settings() -> Settings:
     """Get application settings."""


### PR DESCRIPTION
# Bug Fix: Allow Extra Environment Variables in Settings

## Problem

When `celo-mcp` is run in a project directory that contains a `.env` file with variables
unrelated to the server (e.g. `PRIVATE_KEY`, `DATABASE_URL`, etc.), the server crashes on startup with:

```
pydantic_core._pydantic_core.ValidationError: 1 validation error for Settings
private_key
  Extra inputs are not permitted [type=extra_forbidden, ...]
```

### Root Cause

`pydantic-settings` automatically loads the `.env` file from the current working directory
(configured via `env_file = ".env"` in `Settings.Config`). Since newer versions of
`pydantic-settings` default to `extra = "forbid"`, **any** variable in `.env` that is not
a recognized `Settings` field causes a hard crash — even though those variables are
completely unrelated to `celo-mcp`.

This affects any user running `celo-mcp` from a project directory that has its own `.env`
file, which is a very common setup (e.g. Web3 projects storing wallet keys, API keys, etc.).

---

## Proposed Fix

Add `extra = "ignore"` to the `Settings.Config` class in `celo_mcp/config/settings.py`:

```python
class Config:
    """Pydantic configuration."""

    env_prefix = "CELO_MCP_"
    env_file = ".env"
    extra = "ignore"  # <-- add this
```

This tells pydantic-settings to silently ignore any `.env` variables that are not part of
the `Settings` model, which is the correct behavior since all recognized settings are already
namespaced under the `CELO_MCP_` prefix.

---

## Why This Is Safe

- All legitimate `celo-mcp` settings are already protected by the `CELO_MCP_` prefix,
  so there is no risk of accidentally picking up unintended values.
- Ignoring unknown variables is standard practice for tools that load `.env` files
  in a shared project environment.
- No existing functionality is changed — only the crash behavior is removed.

---

## Steps to Reproduce

1. Create a `.env` file in your working directory with any non-`CELO_MCP_` variable:
   ```
   PRIVATE_KEY=0xabc123...
   ```
2. Run `celo-mcp` from that directory.
3. Server crashes immediately with a `ValidationError` on startup:

```
File ".../celo_mcp/server.py", line 608, in main_sync
    asyncio.run(main())
  File ".../celo_mcp/server.py", line 579, in main
    setup_logging()
  File ".../celo_mcp/utils/logging.py", line 34, in setup_logging
    settings = get_settings()
  File ".../celo_mcp/config/settings.py", line 38, in get_settings
    return Settings()
pydantic_core._pydantic_core.ValidationError: 1 validation error for Settings
private_key
  Extra inputs are not permitted [type=extra_forbidden, input_value='0xeb...', input_type=str]
```

---

## Additional Notes

- This was discovered while integrating `celo-mcp` with Claude Code on **WSL2 Ubuntu**,
  where the MCP server is launched from the project root which naturally contains a `.env` file.
- On WSL2 Ubuntu, environment variables from `.env` files are commonly used by other tools
  in the same project (e.g. wallet private keys for Web3 development), making this crash
  very easy to hit.
- The `--refresh` flag used in the recommended `uvx` setup means any local workaround
  (manually patching the installed package) gets wiped on every update.

@viral-sangani